### PR TITLE
try test on win32 again

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   - julia_version: nightly
 
 platform:
-#  - x86 # 32-bit
+  - x86 # 32-bit
   - x64 # 64-bit
 
 # # Uncomment the following lines to allow failures on nightly julia

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -172,8 +172,8 @@ end
 function _crossrecurrencematrix(x::Dataset, y::Dataset, ε, metric::Metric)
     x = x.data
     y = y.data
-    rowvals = Vector{Int64}()
-    colvals = Vector{Int64}()
+    rowvals = Vector{Int}()
+    colvals = Vector{Int}()
     for j in 1:length(y)
         nzcol = 0
         for i in 1:length(x)


### PR DESCRIPTION
Found that there was some code in `matrices.jl` explicitly creating the recurrence matrix with `Int64` indices. Changed to see if win32 works.