### PR TITLE
Pretty printing of recurrence matrices

### DIFF
--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -106,7 +106,9 @@ function Base.summary(R::AbstractRecurrenceMatrix)
 end
 function Base.show(io::IO, R::AbstractRecurrenceMatrix)
     s = sprint(io -> show(IOContext(io, :limit=>true), MIME"text/plain"(), R.data))
-    s = join(split(s, '\n')[2:end], '\n')
+    s = split(s, '\n')[2:end]
+    s = [replace(line, "=  true"=>"", count=1) for line in s]
+    s = join(s, '\n')
     tos = summary(R)*"\n"*s
     println(io, tos)
 end


### PR DESCRIPTION
@Datseris , to make a cleaner printing of recurrence matrices, I have changed their `show` method, removing the fragment `"=  true"` that is redundant (only the points with `true` values are indexed).

I'm not sure if this is robust (it won't work if the text is not exactly `"=  true"` in some context), but at least should be safe (the worst that can happen is that no change is made).