### PR TITLE
[WIP] Rework test suite

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+DynamicalSystemsBase 1.1


### PR DESCRIPTION
The current tests have some problems. They test only a very specific trajectory of a very specific system. Although we both have no doubt that the package works as claimed, these tests can be seem as kind of fishy. 

They also were testing _exact_ values of RR, DET, etc. These kind of tests work only for the exact trajectory that was in the tests and not for the Lorenz system as a whole. So if one changed the integration window even slightly the tests would fail.

---

This PR tries to generalize the test suit so these test can be extended to many dynamical systems. For this we can use `DynamicalSystemsBase`, which offers many systems like e.g. `Systems.roessler`. By providing a vector of systems and a vector of test values one can test many systems with the same suite.

I have also replaced all `==` tests with `\approx`. 