### PR TITLE
== and != operators for AbstractRecurrenceMatrix

### DIFF
--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -128,6 +128,11 @@ begin
         end
     end
 end
+
+for operator in [:(==), :(!=)]
+    @eval Base.$operator(x::ARM, y::ARM) = $operator(x.data, y.data)
+end
+
 LinearAlgebra.issymmetric(::RecurrenceMatrix) = true
 # column values in sparse matrix (parallel to rowvals)
 function colvals(x::SparseMatrixCSC)


### PR DESCRIPTION
This fixes the following bug:
```
julia> RecurrenceMatrix(x,ε) == RecurrenceMatrix(x,ε)
false

julia> RecurrenceMatrix(x,ε) != RecurrenceMatrix(x,ε)
true
```
The signatures are `(x::ARM, y::ARM)` not `(x::T, y::T) where {T<:ARM}`.
This allows to compare different subtypes of `AbstractRecurrenceMatrix`; for instance this is also true:

`RecurrenceMatrix(x,ε) == CrossRecurrenceMatrix(x,x,ε)`

Are there other operators that should be added?