### PR TITLE
zero RQA parameters with warning for empty histograms

### DIFF
--- a/src/histograms.jl
+++ b/src/histograms.jl
@@ -138,7 +138,6 @@ function diagonalhistogram(x::ARM; lmin::Integer=2, theiler::Integer=0, kwargs..
             dh[1:nbins_loi] .+= loi_hist
         end
     end
-    (dh==[0]) && @warn "no diagonal lines found in the matrix"
     return dh
 end
 
@@ -153,16 +152,8 @@ function verticalhistograms(x::ARM;
     return _linehistograms(rv,cv,lmin,theiler,distances)
 end
 
-function vl_histogram(x; kwargs...) 
-    h = verticalhistograms(x; kwargs...)[1]
-    (h==[0]) && @warn "no vertical lines found in the matrix"
-    return h
-end
-function rt_histogram(x; kwargs...)
-    h = verticalhistograms(x; kwargs...)[2]
-    (h==[0]) && @warn "no recurrence times found in the matrix"
-    return h
-end
+vl_histogram(x; kwargs...) = verticalhistograms(x; kwargs...)[1]
+rt_histogram(x; kwargs...) = verticalhistograms(x; kwargs...)[2]
 
 """
     recurrencestructures(x::AbstractRecurrenceMatrix;
@@ -212,14 +203,8 @@ function recurrencestructures(x::ARM;
         haskey(kw_v, :theilervert) && (kw_v[:theiler] = kw_v[:theilervert])
         haskey(kw_v, :lminvert) && (kw_v[:lmin] = kw_v[:lminvert])
         vhist = verticalhistograms(x; lmin=lmin, theiler=theiler, kw_v...)
-        if vertical
-            (vhist[1]==[0]) && @warn "no vertical lines found in the matrix"
-            (histograms["vertical"] = vhist[1])
-        end
-        if recurrencetimes
-            (vhist[2]==[0]) && @warn "no recurrence times found in the matrix"
-            (histograms["recurrencetimes"] = vhist[2])
-        end
+        vertical && (histograms["vertical"] = vhist[1])
+        recurrencetimes && (histograms["recurrencetimes"] = vhist[2])
     end
     return histograms
 end

--- a/src/histograms.jl
+++ b/src/histograms.jl
@@ -138,6 +138,7 @@ function diagonalhistogram(x::ARM; lmin::Integer=2, theiler::Integer=0, kwargs..
             dh[1:nbins_loi] .+= loi_hist
         end
     end
+    (dh==[0]) && @warn "no diagonal lines found in the matrix"
     return dh
 end
 
@@ -152,8 +153,16 @@ function verticalhistograms(x::ARM;
     return _linehistograms(rv,cv,lmin,theiler,distances)
 end
 
-vl_histogram(x; kwargs...) = verticalhistograms(x; kwargs...)[1]
-rt_histogram(x; kwargs...) = verticalhistograms(x; kwargs...)[2]
+function vl_histogram(x; kwargs...) 
+    h = verticalhistograms(x; kwargs...)[1]
+    (h==[0]) && @warn "no vertical lines found in the matrix"
+    return h
+end
+function rt_histogram(x; kwargs...)
+    h = verticalhistograms(x; kwargs...)[2]
+    (h==[0]) && @warn "no recurrence times found in the matrix"
+    return h
+end
 
 """
     recurrencestructures(x::AbstractRecurrenceMatrix;
@@ -203,8 +212,14 @@ function recurrencestructures(x::ARM;
         haskey(kw_v, :theilervert) && (kw_v[:theiler] = kw_v[:theilervert])
         haskey(kw_v, :lminvert) && (kw_v[:lmin] = kw_v[:lminvert])
         vhist = verticalhistograms(x; lmin=lmin, theiler=theiler, kw_v...)
-        vertical && (histograms["vertical"] = vhist[1])
-        recurrencetimes && (histograms["recurrencetimes"] = vhist[2])
+        if vertical
+            (vhist[1]==[0]) && @warn "no vertical lines found in the matrix"
+            (histograms["vertical"] = vhist[1])
+        end
+        if recurrencetimes
+            (vhist[2]==[0]) && @warn "no recurrence times found in the matrix"
+            (histograms["recurrencetimes"] = vhist[2])
+        end
     end
     return histograms
 end

--- a/src/rqa.jl
+++ b/src/rqa.jl
@@ -257,8 +257,6 @@ function rqa(x; onlydiagonal=false, kwargs...)
         haskey(kw_v, :theilervert) && (kw_v[:theiler] = kw_v[:theilervert])
         haskey(kw_v, :lminvert) && (kw_v[:lmin] = kw_v[:lminvert])
         vhist, rthist = verticalhistograms(x; kw_v...)
-        (vhist==[0]) && @warn "no vertical lines found in the matrix"
-        (rthist==[0]) && @warn "no recurrence times found in the matrix"
         rr_v = recurrencerate(x; kw_v...)
         return Dict("RR"  => recurrencerate(x; kwargs...),
             "DET"  => _determinism(dhist, rr_d*length(x)),


### PR DESCRIPTION
Closes #41 

A problem is that the warning condition is hit several times during the tests (due to the examples of periodic signals without stationary states and in the windowed analysis).

Maybe it is not necessary to provide warnings. Actually there is nothing wrong with the null results; they are the correct result. Perhaps we could replace `@warn` by `@info`, to just highlight what is happening.