### PR TITLE
_computescale methods for maximum and mean

### DIFF
--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -169,8 +169,9 @@ by the following keyword arguments:
 * `scale=1` : a function of the distance matrix (see [`distancematrix`](@ref)),
   or a fixed number, used to scale the value of `ε`. Typical choices are
   `maximum` or `mean`, such that the threshold `ε` is defined as a ratio of the
-  maximum or the mean distance between data points, respectively.
-  Use `1` to keep the distances unscaled (default).
+  maximum or the mean distance between data points, respectively (using
+  `mean` or `maximum` calls specialized versions that are faster than the naive
+  approach).  Use `1` to keep the distances unscaled (default).
 * `fixedrate::Bool=false` : a flag that indicates if `ε` should be
   taken as a target fixed recurrence rate (see [`recurrencerate`](@ref)).
   If `fixedrate` is set to `true`, `ε` must be a value between 0 and 1,

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -240,13 +240,12 @@ function _computescale(scale::typeof(maximum), x::T, y::T, metric::Metric) where
     end
     return maxvalue
 end
-function _computescale(scale::typeof(mean), x::T, y::T, metric::Metric) where {T}
-    meanvalue = zero(eltype(x))
-    w = 1/(length(x)*length(y))
+function _computescale(scale::typeof(mean), x, y, metric::Metric)
+    meanvalue = 0.0
     @inbounds for xi in x, yj in y
-        meanvalue += evaluate(metric, xi, yj)*w
+        meanvalue += evaluate(metric, xi, yj)
     end
-    return meanvalue
+    return meanvalue/(length(x)*length(y))
 end
 
 

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -231,6 +231,24 @@ end
 # distance matrix; otherwise return the value of `scale` itself
 _computescale(scale::Function, x, y, metric) = scale(distancematrix(x, y, metric))
 _computescale(scale::Real, args...) = scale
+# specific methods to avoid `distancematrix`
+function _computescale(scale::typeof(maximum), x::T, y::T, metric::Metric) where {T}
+    maxvalue = zero(eltype(x))
+    @inbounds for xi in x, yj in y
+        newvalue = evaluate(metric, xi, yj)
+        (newvalue > maxvalue) && (maxvalue = newvalue)
+    end
+    return maxvalue
+end
+function _computescale(scale::typeof(mean), x::T, y::T, metric::Metric) where {T}
+    meanvalue = zero(eltype(x))
+    w = 1/(length(x)*length(y))
+    @inbounds for xi in x, yj in y
+        meanvalue += evaluate(metric, xi, yj)*w
+    end
+    return meanvalue
+end
+
 
 # Internal methods to calculate the matrix:
 # If the metric is supplied as a string, get the corresponding Metric from Distances


### PR DESCRIPTION
Sometimes the threshold to calculate the recurrence matrices is defined as a fraction of some measure of the phase space. That reference value is often calculated as the maximum or the average of the distances between all data points. The `scale` parameter of `RecurrenceMatrix` etc. may be used for that.

The current implementation calls `distancematrix` when that parameter is a function:
 
https://github.com/JuliaDynamics/RecurrenceAnalysis.jl/blob/2961a32b29e41ea1e3dc3d63f67e29d74948e5ab/src/matrices.jl#L232

But this is very expensive. Compare without and with `scale` (example with c. 10,000 data points in `xe`; the difference in the threshold is to make the resulting matrices similar to each other):

```
julia> @btime RecurrenceMatrix($xe, 1.5);
  954.071 ms (10053 allocations: 187.87 MiB)

julia> @btime RecurrenceMatrix($xe, 0.05, scale=$maximum);
  2.283 s (10055 allocations: 1.03 GiB)
```

With this PR it is reduced to:
```
julia> @btime RecurrenceMatrix($xe, 0.05, scale=$maximum);
  1.618 s (10053 allocations: 290.39 MiB)
```

Saved memory is even more important than time in this case. My computer chokes with `distancematrix` for series of 40,000 data points. But this way I can calculate the recurrence matrix with no big pain.