### PR TITLE
default theiler=1; 0 for cross-recurrence matrices

### DIFF
--- a/src/histograms.jl
+++ b/src/histograms.jl
@@ -103,7 +103,7 @@ function _linehistograms(rows::T, cols::T, lmin::Integer=1, theiler::Integer=0,
     return (bins, bins_d)
 end
 
-function diagonalhistogram(x::ARM; lmin::Integer=2, theiler::Integer=0, kwargs...)
+function diagonalhistogram(x::ARM; lmin::Integer=2, theiler::Integer=1, kwargs...)
     (theiler < 0) && throw(ErrorException(
         "Theiler window length must be greater than or equal to 0"))
     (lmin < 1) && throw(ErrorException("lmin must be 1 or greater"))
@@ -140,9 +140,11 @@ function diagonalhistogram(x::ARM; lmin::Integer=2, theiler::Integer=0, kwargs..
     end
     return dh
 end
-
+diagonalhistogram(x::CrossRecurrenceMatrix; kwargs...) = 
+    diagonalhistogram(_RM(x); theiler=0, kwargs...)
+    
 function verticalhistograms(x::ARM;
-    lmin::Integer=2, theiler::Integer=0, distances=true, kwargs...)
+    lmin::Integer=2, theiler::Integer=1, distances=true, kwargs...)
     (theiler < 0) && throw(ErrorException(
         "Theiler window length must be greater than or equal to 0"))
     (lmin < 1) && throw(ErrorException("lmin must be 1 or greater"))
@@ -151,6 +153,8 @@ function verticalhistograms(x::ARM;
     cv = colvals(x)
     return _linehistograms(rv,cv,lmin,theiler,distances)
 end
+verticalhistograms(x::CrossRecurrenceMatrix; kwargs...) = 
+    verticalhistograms(_RM(x); theiler=0, kwargs...)
 
 vl_histogram(x; kwargs...) = verticalhistograms(x; kwargs...)[1]
 rt_histogram(x; kwargs...) = verticalhistograms(x; kwargs...)[2]
@@ -191,7 +195,7 @@ recurrence quantifications", in: Webber, C.L. & N. Marwan (eds.), *Recurrence
 Quantification Analysis. Theory and Best Practices*, Springer, pp. 3-43 (2015).
 """
 function recurrencestructures(x::ARM;
-    diagonal=true, vertical=true, recurrencetimes=true, lmin=1, theiler=0, kwargs...)
+    diagonal=true, vertical=true, recurrencetimes=true, lmin=1, theiler=1, kwargs...)
 
     # Parse arguments for diagonal and vertical structures
     histograms = Dict{String,Vector{Int}}()
@@ -211,3 +215,5 @@ function recurrencestructures(x::ARM;
     end
     return histograms
 end
+recurrencestructures(x::CrossRecurrenceMatrix; kwargs...) = 
+    recurrencestructures(_RM(x); theiler=0, kwargs...)

--- a/src/histograms.jl
+++ b/src/histograms.jl
@@ -103,7 +103,10 @@ function _linehistograms(rows::T, cols::T, lmin::Integer=1, theiler::Integer=0,
     return (bins, bins_d)
 end
 
-function diagonalhistogram(x::ARM; lmin::Integer=2, theiler::Integer=1, kwargs...)
+deftheiler(x::ARM) = 1
+deftheiler(x::CrossRecurrenceMatrix) = 0
+
+function diagonalhistogram(x::ARM; lmin::Integer=2, theiler::Integer=deftheiler(x), kwargs...)
     (theiler < 0) && throw(ErrorException(
         "Theiler window length must be greater than or equal to 0"))
     (lmin < 1) && throw(ErrorException("lmin must be 1 or greater"))
@@ -140,11 +143,9 @@ function diagonalhistogram(x::ARM; lmin::Integer=2, theiler::Integer=1, kwargs..
     end
     return dh
 end
-diagonalhistogram(x::CrossRecurrenceMatrix; kwargs...) = 
-    diagonalhistogram(_RM(x); theiler=0, kwargs...)
     
 function verticalhistograms(x::ARM;
-    lmin::Integer=2, theiler::Integer=1, distances=true, kwargs...)
+    lmin::Integer=2, theiler::Integer=deftheiler(x), distances=true, kwargs...)
     (theiler < 0) && throw(ErrorException(
         "Theiler window length must be greater than or equal to 0"))
     (lmin < 1) && throw(ErrorException("lmin must be 1 or greater"))
@@ -153,8 +154,6 @@ function verticalhistograms(x::ARM;
     cv = colvals(x)
     return _linehistograms(rv,cv,lmin,theiler,distances)
 end
-verticalhistograms(x::CrossRecurrenceMatrix; kwargs...) = 
-    verticalhistograms(_RM(x); theiler=0, kwargs...)
 
 vl_histogram(x; kwargs...) = verticalhistograms(x; kwargs...)[1]
 rt_histogram(x; kwargs...) = verticalhistograms(x; kwargs...)[2]
@@ -195,7 +194,8 @@ recurrence quantifications", in: Webber, C.L. & N. Marwan (eds.), *Recurrence
 Quantification Analysis. Theory and Best Practices*, Springer, pp. 3-43 (2015).
 """
 function recurrencestructures(x::ARM;
-    diagonal=true, vertical=true, recurrencetimes=true, lmin=1, theiler=1, kwargs...)
+    diagonal=true, vertical=true, recurrencetimes=true,
+    lmin=1, theiler=deftheiler(x), kwargs...)
 
     # Parse arguments for diagonal and vertical structures
     histograms = Dict{String,Vector{Int}}()
@@ -215,5 +215,4 @@ function recurrencestructures(x::ARM;
     end
     return histograms
 end
-recurrencestructures(x::CrossRecurrenceMatrix; kwargs...) = 
-    recurrencestructures(_RM(x); theiler=0, kwargs...)
+

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -101,11 +101,6 @@ end
 struct JointRecurrenceMatrix <: AbstractRecurrenceMatrix
     data::SparseMatrixCSC{Bool,Int}
 end
-# Special type (not exported) to manage conditional parameters in methods
-struct _RM <: AbstractRecurrenceMatrix
-    data::SparseMatrixCSC{Bool,Int}
-end
-_RM(R::ARM) = _RM(R.data)
 
 function Base.summary(R::AbstractRecurrenceMatrix)
     N = nnz(R.data)

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -101,6 +101,11 @@ end
 struct JointRecurrenceMatrix <: AbstractRecurrenceMatrix
     data::SparseMatrixCSC{Bool,Int}
 end
+# Special type (not exported) to manage conditional parameters in methods
+struct _RM <: AbstractRecurrenceMatrix
+    data::SparseMatrixCSC{Bool,Int}
+end
+_RM(R::ARM) = _RM(R.data)
 
 function Base.summary(R::AbstractRecurrenceMatrix)
     N = nnz(R.data)

--- a/src/rqa.jl
+++ b/src/rqa.jl
@@ -3,10 +3,14 @@
 # Recurrence rate
 
 """
-    recurrencerate(x; theiler=0)
+    recurrencerate(x[; theiler::Integer])
 
-Calculate the recurrence rate of the recurrence matrix `x`, ruling out
-the points within the Theiler window of size `theiler`.
+Calculate the recurrence rate of the recurrence matrix `x`.
+
+The line of identity (main diagonal) is excluded by default for matrices of type
+`RecurrenceMatrix` or `JointRecurrenceMatrix`, but included for matrices of type
+`CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
+diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 """
 function recurrencerate(x::ARM; theiler::Integer=0, kwargs...)::Float64
     (theiler < 0) && throw(ErrorException(
@@ -52,11 +56,15 @@ macro histogram_params(keyword, description, hist_fun)
         _fname = Symbol("_$(keyword)_$(name)")
         fbody = function_bodies[name]
         doc = """
-                $fname(x; lmin=2, theiler=0)
+                $fname(x[; lmin=2, theiler])
 
             Calculate the $(param) contained in the recurrence matrix `x`,
-            ruling out the points within the Theiler window of size `theiler`
-            and diagonals shorter than `lmin`.
+            ruling out the lines shorter than `lmin`.
+            
+            The line of identity (main diagonal) is excluded by default for matrices of type
+            `RecurrenceMatrix` or `JointRecurrenceMatrix`, but included for matrices of type
+            `CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
+            diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
             """
         push!(ret.args, quote
             @doc $doc ->
@@ -80,11 +88,15 @@ end
 @deprecate rqaentropy dl_entropy
 
 """
-    determinism(x; lmin=2, theiler=0)
+    determinism(x[; lmin=2, theiler])
 
 Calculate the determinism of the recurrence matrix `x`, ruling out
-the points within the Theiler window of size `theiler` and diagonals shorter
-than `lmin`.
+the diagonal lines shorter than `lmin`.
+
+The line of identity (main diagonal) is excluded by default for matrices of type
+`RecurrenceMatrix` or `JointRecurrenceMatrix`, but included for matrices of type
+`CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
+diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 """
 function determinism(x::ARM; kwargs...)
     npoints = recurrencerate(x; kwargs...)*length(x)
@@ -99,32 +111,37 @@ end
 
 
 """
-    divergence(x; theiler=0)
+    divergence(x[; theiler])
 
 Calculate the divergence of the recurrence matrix `x`
-(actually the inverse of [`dl_max`](@ref)), ruling out
-the points within the Theiler window of size `theiler`.
+(actually the inverse of [`dl_max`](@ref)).
 """
 divergence(x::ARM; kwargs...) = ( 1.0/dl_max(x; kwargs...) )
 
 
 """
-    trend(x; theiler=0, border=10)
+    trend(x[; border=10, theiler])
 
-Calculate the trend of recurrences in the recurrence matrix `x`
-towards its edges, ruling out the points within the Theiler window of size `theiler`.
+Calculate the trend of recurrences in the recurrence matrix `x`.
 
-Keyword `border` can also exclude outermost diagonals
-(i.e. counting from the corners of the matrix).
+The 10 outermost diagonals (counting from the corners of the matrix)
+are excluded by default to avoid "border effects". Use the keyword argument
+`border` to define a different number of excluded lines.
+
+The line of identity (main diagonal) is excluded by default for matrices of type
+`RecurrenceMatrix` or `JointRecurrenceMatrix`, but included for matrices of type
+`CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
+diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 """
 trend(x::ARM; kwargs...) = _trend(tau_recurrence(x); kwargs...)
+trend(x::CrossRecurrenceMatrix, kwargs...) = trend(_RM(x), theiler=0, kwargs...)
 
 function tau_recurrence(x::ARM)
     n = minimum(size(x))
     [count(!iszero, diag(x,d))/(n-d) for d in (0:n-1)]
 end
 
-function _trend(npoints::Vector; theiler=0, border=10, kwargs...)::Float64
+function _trend(npoints::Vector; theiler=1, border=10, kwargs...)::Float64
     nmax = length(npoints)
     rrk = npoints./collect(nmax:-1:1)
     a = 1+theiler
@@ -150,11 +167,15 @@ end
 @deprecate maxvert vl_max
 
 """
-    laminarity(x; lmin=2, theiler=0)
+    laminarity(x[; lmin=2, theiler])
 
 Calculate the laminarity of the recurrence matrix `x`, ruling out the
-points within the Theiler window of size `theiler` and lines shorter
-than `lmin`.
+lines shorter than `lmin`.
+
+The line of identity (main diagonal) is excluded by default for matrices of type
+`RecurrenceMatrix` or `JointRecurrenceMatrix`, but included for matrices of type
+`CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
+diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 """
 function laminarity(x::ARM; kwargs...)
     npoints = recurrencerate(x)*length(x)
@@ -167,8 +188,12 @@ _laminarity(vert_hist::Vector{<:Integer}, npoints) = _determinism(vert_hist, npo
     trappingtime(x; lmin=2, theiler=0)
 
 Calculate the trapping time of the recurrence matrix `x`, ruling out the
-points within the Theiler window of size `theiler` and lines shorter
-than `lmin`.
+lines shorter than `lmin`.
+
+The line of identity (main diagonal) is excluded by default for matrices of type
+`RecurrenceMatrix` or `JointRecurrenceMatrix`, but included for matrices of type
+`CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
+diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 
 The trapping time is the average of the vertical line structures and thus equal
 to [`vl_average`](@ref).
@@ -184,8 +209,12 @@ trappingtime(x::ARM; kwargs...) = vl_average(x; kwargs...)
     meanrecurrencetime(x; lmin=2, theiler=0)
 
 Calculate the mean recurrence time of the recurrence matrix `x`, ruling out the
-points within the Theiler window of size `theiler` and lines shorter
-than `lmin`.
+lines shorter than `lmin`.
+
+The line of identity (main diagonal) is excluded by default for matrices of type
+`RecurrenceMatrix` or `JointRecurrenceMatrix`, but included for matrices of type
+`CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
+diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 
 Equivalent to [`rt_average`](@ref).
 """
@@ -196,8 +225,12 @@ meanrecurrencetime(x::ARM; kwargs...) = rt_average(x; kwargs...)
     nmprt(x; lmin=2, theiler=0)
 
 Calculate the number of the most probable recurrence time (NMPRT), ruling out the
-points within the Theiler window of size `theiler` and lines shorter
-than `lmin`.
+lines shorter than `lmin`.
+
+The line of identity (main diagonal) is excluded by default for matrices of type
+`RecurrenceMatrix` or `JointRecurrenceMatrix`, but included for matrices of type
+`CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
+diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 """
 nmprt(x::ARM; kwargs) = maximum(verticalhistograms(x; kwargs...)[2])
 

--- a/src/rqa.jl
+++ b/src/rqa.jl
@@ -12,7 +12,7 @@ The line of identity (main diagonal) is excluded by default for matrices of type
 `CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
 diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 """
-function recurrencerate(x::ARM; theiler::Integer=0, kwargs...)::Float64
+function recurrencerate(x::ARM; theiler::Integer=1, kwargs...)::Float64
     (theiler < 0) && throw(ErrorException(
         "Theiler window length must be greater than or equal to 0"))
     if theiler == 0
@@ -25,6 +25,8 @@ function recurrencerate(x::ARM; theiler::Integer=0, kwargs...)::Float64
     end
     return (nnz(x) - theiler_nz)/length(x)
 end
+recurrencerate(x::CrossRecurrenceMatrix, kwargs...) = 
+    recurrencerate(_RM(x); theiler=0, kwargs...)
 
 # Generic parameters of histograms: mean, average and entropy
 

--- a/src/rqa.jl
+++ b/src/rqa.jl
@@ -12,7 +12,7 @@ The line of identity (main diagonal) is excluded by default for matrices of type
 `CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
 diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 """
-function recurrencerate(x::ARM; theiler::Integer=1, kwargs...)::Float64
+function recurrencerate(x::ARM; theiler::Integer=deftheiler(x), kwargs...)::Float64
     (theiler < 0) && throw(ErrorException(
         "Theiler window length must be greater than or equal to 0"))
     if theiler == 0
@@ -25,8 +25,6 @@ function recurrencerate(x::ARM; theiler::Integer=1, kwargs...)::Float64
     end
     return (nnz(x) - theiler_nz)/length(x)
 end
-recurrencerate(x::CrossRecurrenceMatrix, kwargs...) = 
-    recurrencerate(_RM(x); theiler=0, kwargs...)
 
 # Generic parameters of histograms: mean, average and entropy
 
@@ -135,8 +133,8 @@ The line of identity (main diagonal) is excluded by default for matrices of type
 `CrossRecurrenceMatrix`. Use the keyword argument `theiler` to exclude the
 diagonals within a custom Theiler window (`theiler=0` to include all diagonals).
 """
-trend(x::ARM; kwargs...) = _trend(tau_recurrence(x); kwargs...)
-trend(x::CrossRecurrenceMatrix, kwargs...) = trend(_RM(x), theiler=0, kwargs...)
+trend(x::ARM; theiler=deftheiler(x), kwargs...) =
+    _trend(tau_recurrence(x); theiler=theiler, kwargs...)
 
 function tau_recurrence(x::ARM)
     n = minimum(size(x))


### PR DESCRIPTION
Closes #45 

It was a bit more difficult than what I expected, because redefining the methods for `CrossRecurrenceMatrix` with only a change in keyword arguments led me to recursive calls!

Finally I have achieved it using a "dummy" type `_RM<:AbstractRecurrenceMatrix`

https://github.com/JuliaDynamics/RecurrenceAnalysis.jl/blob/65b23c6a147c27e591f1a6ed1ad1ce9e9041f2b5/src/matrices.jl#L104-L108

But perhaps there is a smarter solution that I missed...