### PR TITLE
Fix `trend`

### DIFF
--- a/src/rqa.jl
+++ b/src/rqa.jl
@@ -155,16 +155,17 @@ trend(x::ARM; theiler=deftheiler(x), kwargs...) =
 
 function tau_recurrence(x::ARM)
     n = minimum(size(x))
-    [count(!iszero, diag(x,d))/(n-d) for d in (0:n-1)]
+    rr_τ1 = [count(!iszero, diag(x,d))/(n-d) for d in (0:n-1)]
+    rr_τ2 = [count(!iszero, diag(x,-d))/(n-d) for d in (0:n-1)]
+    return (rr_τ1 + rr_τ2)
 end
 
-function _trend(npoints::Vector; theiler=1, border=10, kwargs...)::Float64
-    nmax = length(npoints)
-    rrk = npoints./collect(nmax:-1:1)
+function _trend(rr_τ::Vector; theiler=1, border=10, kwargs...)::Float64
+    nmax = length(rr_τ)
     a = 1+theiler
     b = nmax-border
     w = collect(a:b) .- b/2
-    (w'*(rrk[a:b] .- mean(rrk[a:b])) ./ (w'*w))[1]
+    (w'*(rr_τ[a:b] .- mean(rr_τ[a:b])) ./ (w'*w))[1]
 end
 
 # Number of l-length sequences, based on diagonals

--- a/src/rqa.jl
+++ b/src/rqa.jl
@@ -155,8 +155,8 @@ trend(x::ARM; theiler=deftheiler(x), kwargs...) =
 
 function tau_recurrence(x::ARM)
     n = minimum(size(x))
-    rr_τ1 = [count(!iszero, diag(x,d))/(n-d) for d in (0:n-1)]
-    rr_τ2 = [count(!iszero, diag(x,-d))/(n-d) for d in (0:n-1)]
+    rr_τ1 = [count(!iszero, diag(x,d))/length(diag(x,d)) for d in (0:n-1)]
+    rr_τ2 = [count(!iszero, diag(x,-d))/length(diag(x,-d)) for d in (0:n-1)]
     return (rr_τ1 + rr_τ2)
 end
 

--- a/test/smallmatrix.jl
+++ b/test/smallmatrix.jl
@@ -35,13 +35,14 @@ rmat = CrossRecurrenceMatrix(sparse(i,j,trues(length(i))))
         for k in keys(histograms)
             @test histograms[k] == true_histograms[k]
         end
-        rqa_params = rqa(rmat, theiler=0, lmin=1)
+        rqa_params = rqa(rmat, theiler=0, lmin=1, border=1)
         @test rqa_params["RR"] == 33/110
         @test rqa_params["DET"] == 1.0
         @test rqa_params["L"] == 33/20
         @test rqa_params["Lmax"] == 5
         @test rqa_params["DIV"] == 0.2
         @test rqa_params["ENTR"] ≈ 0.996 atol=0.001
+        @test rqa_params["TREND"] ≈ -5.450e-2 atol=0.001
         @test rqa_params["LAM"] == 1.0
         @test rqa_params["TT"] == 33/23
         @test rqa_params["Vmax"] == 3
@@ -57,13 +58,14 @@ rmat = CrossRecurrenceMatrix(sparse(i,j,trues(length(i))))
         for k in keys(histograms)
             @test histograms[k] == true_histograms[k]
         end
-        rqa_params = rqa(rmat, theiler=2, lmin=1)
+        rqa_params = rqa(rmat, theiler=2, lmin=1, border=1)
         @test rqa_params["RR"] == 22/110
         @test rqa_params["DET"] == 1.0
         @test rqa_params["L"] == 22/14
         @test rqa_params["Lmax"] == 5
         @test rqa_params["DIV"] == 0.2
         @test rqa_params["ENTR"] ≈ 0.830 atol=0.001
+        @test rqa_params["TREND"] ≈ -8.98e-3 atol=1e-6
         @test rqa_params["LAM"] == 1.0
         @test rqa_params["TT"] == 22/15
         @test rqa_params["Vmax"] == 3
@@ -79,13 +81,14 @@ rmat = CrossRecurrenceMatrix(sparse(i,j,trues(length(i))))
         for k in keys(histograms)
             @test histograms[k] == true_histograms[k]
         end
-        rqa_params = rqa(rmat, theiler=0, lmin=2)
+        rqa_params = rqa(rmat, theiler=0, lmin=2, border=1)
         @test rqa_params["RR"] == 33/110
         @test rqa_params["DET"] == 22/33
         @test rqa_params["L"] == 22/9
         @test rqa_params["Lmax"] == 5
         @test rqa_params["DIV"] == 0.2
         @test rqa_params["ENTR"] ≈ 0.684 atol=0.001
+        @test rqa_params["TREND"] ≈ -5.450e-2 atol=0.001
         @test rqa_params["LAM"] == 18/33
         @test rqa_params["TT"] == 18/8
         @test rqa_params["Vmax"] == 3
@@ -101,13 +104,14 @@ rmat = CrossRecurrenceMatrix(sparse(i,j,trues(length(i))))
         for k in keys(histograms)
             @test histograms[k] == true_histograms[k]
         end
-        rqa_params = rqa(rmat, theiler=2, lmin=2)
+        rqa_params = rqa(rmat, theiler=2, lmin=2, border=1)
         @test rqa_params["RR"] == 22/110
         @test rqa_params["DET"] == 13/22
         @test rqa_params["L"] == 13/5
         @test rqa_params["Lmax"] == 5
         @test rqa_params["DIV"] == 0.2
         @test rqa_params["ENTR"] ≈ 0.500 atol=0.001
+        @test rqa_params["TREND"] ≈ -8.98e-3 atol=1e-6
         @test rqa_params["LAM"] == 12/22
         @test rqa_params["TT"] == 12/5
         @test rqa_params["Vmax"] == 3


### PR DESCRIPTION
The calculation of the TREND parameter was wrong, although I had not the opportunity to test it against the result of other packages - because the ones that I used do not report that parameter!

I have now validated it with the manual calculation made with the "small matrix" (`test/smallmatrix.jl`). The results are also consistent with the values reported in published examples (e.g. the Hénon map tested in `test/dynamicalsystems.jl`, copied from Webber's and Zbilut's chapter on RQA).