### PR TITLE
fix `_computescale(scale::typeof(mean), x, y, ...)`

### DIFF
--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -225,7 +225,7 @@ end
 _computescale(scale::Function, x, y, metric) = scale(distancematrix(x, y, metric))
 _computescale(scale::Real, args...) = scale
 # specific methods to avoid `distancematrix`
-function _computescale(scale::typeof(maximum), x::T, y::T, metric::Metric) where {T}
+function _computescale(scale::typeof(maximum), x, y, metric::Metric)
     maxvalue = zero(eltype(x))
     @inbounds for xi in x, yj in y
         newvalue = evaluate(metric, xi, yj)
@@ -238,7 +238,8 @@ function _computescale(scale::typeof(mean), x, y, metric::Metric)
     @inbounds for xi in x, yj in y
         meanvalue += evaluate(metric, xi, yj)
     end
-    return meanvalue/(length(x)*length(y))
+    denominator = (x==y) ? length(x)*(length(y)-1) : length(x)*length(y)
+    return meanvalue/denominator
 end
 
 


### PR DESCRIPTION
`_computescale` is used to set the threshold of recurrences in a recurrence plot as a relative value, proportional to by the "size" of the phase space.

Thus, `scale=mean` should give as scale the average distance between data points of the trajectories `x` and `y`. If `x==y`, this average should exclude distances between a point and itself, isn't it?.

This PR fixes this - although the result is different as the one that provided the general and simpler but heavier definition `_computescale(scale::Function, x, y, metric) = scale(distancematrix(x, y, metric))`.

In any case, the difference is negligible for long time series.