### PR TITLE
specialize _computescale for identical inputs

### DIFF
--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -224,10 +224,8 @@ function _computescale(scale::Function, x, y, metric)
     if x===y
         distances = zeros(Int(length(x)*(length(x)-1)/2))
         c = 0
-        @inbounds for (i,xi) in enumerate(x), (j,yj) in enumerate(y)
-            if j > i
-                distances[c+=1] = evaluate(metric, xi, yj)
-            end
+        @inbounds for i in 1:length(x)-1, j=(i+1):length(x)
+            distances[c+=1] = evaluate(metric, x[i], y[j])
         end
     else
         distances = distancematrix(x, y, metric)
@@ -238,11 +236,9 @@ end
 function _computescale(scale::typeof(maximum), x, y, metric::Metric)
     maxvalue = zero(eltype(x))
     if x===y
-        @inbounds for (i,xi) in enumerate(x), (j,yj) in enumerate(y)
-            if j > i
-                newvalue = evaluate(metric, xi, yj)
-                (newvalue > maxvalue) && (maxvalue = newvalue)
-            end
+        @inbounds for i in 1:length(x)-1, j=(i+1):length(x)
+            newvalue = evaluate(metric, x[i], y[j])
+            (newvalue > maxvalue) && (maxvalue = newvalue)
         end
     else
         @inbounds for xi in x, yj in y
@@ -255,10 +251,8 @@ end
 function _computescale(scale::typeof(mean), x, y, metric::Metric)
     meanvalue = 0.0
     if x===y
-        @inbounds for (i,xi) in enumerate(x), (j,yj) in enumerate(y)
-            if j > i
-                meanvalue += evaluate(metric, xi, yj)
-            end
+        @inbounds for i in 1:length(x)-1, j=(i+1):length(x)
+            meanvalue += evaluate(metric, x[i], y[j])
         end
         denominator = length(x)*(length(x)-1)/2
     else


### PR DESCRIPTION
The methods for `mean` and `maximum` give identical results, but here they are faster when used by `RecurrenceMatrix`because half of the values need not be calculated.

The general method of `_computescale` will give different results when used by `RecurrenceMatrix`, because `distances` will only have half of the values contained in the distance matrix, excluding the main diagonal. But this will make it consistent with the values returned when `mean` and `maximum` are used.

The condition is `x===y`, not `x==y`, because it is faster (the slowest case for `x==y` is precisely when both vectors have the same values, which will always happen for `RecurrenceMatrix`; with `x===y` the identity will be found immediately).