### PR TITLE
test on Julia 1.0 (LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: julia
 os:
   - linux
 julia:
+  - 1.0
   - 1.1
   # - nightly
 branches:


### PR DESCRIPTION
I think Julia 1.0 should be restored in the tests, because that's the long term support version of Julia, and packages should aim at providing LTS as well. If that test breaks in the future, a branch to support 1.0 can be created and maintained separately. 