### PR TITLE
Parallelize recurrence matrix construction

### DIFF
--- a/src/RecurrenceAnalysis.jl
+++ b/src/RecurrenceAnalysis.jl
@@ -2,6 +2,7 @@ module RecurrenceAnalysis
 
 using Distances, Statistics, LinearAlgebra, SparseArrays, DelayEmbeddings, StaticArrays
 import Base.Meta.parse
+using Base.Threads
 
 export RecurrenceMatrix, CrossRecurrenceMatrix, JointRecurrenceMatrix,
        AbstractRecurrenceMatrix


### PR DESCRIPTION
Adds a kwarg to `_recurrence_matrix`, which controls whether the 
parallel or serial algorithm is called.

Partially fixes #76 