### PR TITLE
Only calculate the lower triangle

### DIFF
--- a/benchmarks/parallel_vs_serial.jl
+++ b/benchmarks/parallel_vs_serial.jl
@@ -4,21 +4,71 @@ This file benchmarks the parallel and serial computation of a recurrence matrix
 using DynamicalSystemsBase, RecurrenceAnalysis
 using Statistics, BenchmarkTools, Base.Threads
 
+function pretty_time(b::BenchmarkTools.Trial)
+    med = median(b)
+
+    return string(
+        BenchmarkTools.prettytime(BenchmarkTools.time(med)),
+        " (",
+        BenchmarkTools.prettypercent(BenchmarkTools.gcratio(med)),
+        " GC)"
+    )
+
+end
+
 Ns = round.(Int, 10.0 .^ (2:0.5:4.5))
 ro = Systems.roessler()
 
-println("I am using $(nthreads()) threads. I am reporting results as:")
-println("time of (parallel/serial) for 3D and 1D trajectories.")
+println("I am using $(nthreads()) threads.")
 for N in Ns
+    # set up datasets
     tr = trajectory(ro, N*0.1; dt = 0.1, Tr = 10.0)
-    println("For N = $(length(tr))...")
+    printstyled("For N = $(length(tr))..."; color = :blue, bold = true)
+    println()
     x = tr[:, 1]
+
+    # calculate only the lower triangle
     b_serial   = @benchmark RecurrenceMatrix($(tr), 5.0; metric = Euclidean(), parallel = false)
     b_parallel = @benchmark RecurrenceMatrix($(tr), 5.0; metric = Euclidean(), parallel = true)
     b_s_1 = @benchmark RecurrenceMatrix($(x), 2.0; parallel = false)
     b_p_1 = @benchmark RecurrenceMatrix($(x), 2.0; parallel = true)
+
+    # calculate triangular metrics
     threeD = median(b_serial.times)/median(b_parallel.times)
     oneD = median(b_s_1.times)/median(b_p_1.times)
     threeD, oneD = round.((threeD, oneD); sigdigits = 3)
-    println("3D=$(threeD), 1D=$(oneD)")
+    printstyled("Lower triangle only"; color = :green)
+    println("\nSpeedups: \n    3D=$threeD\n    1D=$oneD")
+    println(
+        """
+        Raw timings:
+            3D serial:   $(pretty_time(b_serial))
+            3D parallel: $(pretty_time(b_parallel))
+            1D serial:   $(pretty_time(b_s_1))
+            1D parallel: $(pretty_time(b_p_1))
+        """
+    )
+
+    # calculate the full matrix
+    b_serial_full   = @benchmark CrossRecurrenceMatrix($(tr), $(tr), 5.0; metric = Euclidean(), parallel = false)
+    b_parallel_full = @benchmark CrossRecurrenceMatrix($(tr), $(tr), 5.0; metric = Euclidean(), parallel = true)
+    b_s_1_full = @benchmark CrossRecurrenceMatrix($(x), $(x), 2.0; parallel = false)
+    b_p_1_full = @benchmark CrossRecurrenceMatrix($(x), $(x), 2.0; parallel = true)
+
+    # calculate full metrics
+    threeD = median(b_serial_full.times)/median(b_parallel_full.times)
+    oneD = median(b_s_1_full.times)/median(b_p_1_full.times)
+    threeD, oneD = round.((threeD, oneD); sigdigits = 3)
+    printstyled("Full matrix"; color = :green)
+    println("\nSpeedups: \n    3D=$threeD\n    1D=$oneD")
+    println(
+        """
+        Raw timings:
+            3D serial:   $(pretty_time(b_serial_full))
+            3D parallel: $(pretty_time(b_parallel_full))
+            1D serial:   $(pretty_time(b_s_1_full))
+            1D parallel: $(pretty_time(b_p_1_full))
+        """
+    )
+    println()
 end

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -368,7 +368,7 @@ function recurrence_matrix(x::AbstractVector, metric::Metric, ε::Real, parallel
         append!(colvals, fill(j, (nzcol,)))
     end
     nzvals = fill(true, (length(rowvals),))
-    return Symmetric(sparse(rowvals, colvals, nzvals, length(x), length(x)), :L)
+    return Symmetric(sparse(rowvals, colvals, nzvals, length(x), length(x)), :U)
 end
 
 function recurrence_matrix(xx::Dataset, metric::Metric, ε::Real, parallel::Val{false})
@@ -386,7 +386,7 @@ function recurrence_matrix(xx::Dataset, metric::Metric, ε::Real, parallel::Val{
         append!(colvals, fill(j, (nzcol,)))
     end
     nzvals = fill(true, (length(rowvals),))
-    return Symmetric(sparse(rowvals, colvals, nzvals, length(x), length(x)), :L)
+    return Symmetric(sparse(rowvals, colvals, nzvals, length(x), length(x)), :U)
 end
 
 
@@ -496,7 +496,7 @@ function recurrence_matrix(xx::AbstractVector, metric::Metric, ε::Real, paralle
     finalrows = vcat(rowvals...) # merge into one array
     finalcols = vcat(colvals...) # merge into one array
     nzvals = fill(true, (length(finalrows),))
-    return sparse(finalrows, finalcols, nzvals, length(x), length(x))
+    return Symmetric(sparse(finalrows, finalcols, nzvals, length(x), length(x)), :U)
 end
 
 function recurrence_matrix(xx::Dataset, metric::Metric, ε::Real, parallel::Val{true})
@@ -524,5 +524,5 @@ function recurrence_matrix(xx::Dataset, metric::Metric, ε::Real, parallel::Val{
     finalrows = vcat(rowvals...) # merge into one array
     finalcols = vcat(colvals...) # merge into one array
     nzvals = fill(true, (length(finalrows),))
-    return sparse(finalrows, finalcols, nzvals, length(x), length(x))
+    return Symmetric(sparse(finalrows, finalcols, nzvals, length(x), length(x)), :U)
 end


### PR DESCRIPTION
This PR successfully implements a serial and parallel version of the single-trajectory recurrence matrix calculation.  By only calculating the lower triangle's recurrence, we can save on a significant amount of time.

In parallel, what I've done is to equalize the number of calculations per thread, by partitioning the array such that each thread has an equal "area" to iterate over.  If the whole iteration space is a triangle, then what I did here is to partition it into trapezoids of equal area.

Fixes #76!