### PR TITLE
fix references and NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # RecurrenceAnalysis.jl News
 
+## v1.5.1
+- Minor documentation fixes.
+
+## v1.5.0
+- Integration with `LightGraphs` to create recurrence networks, and `rna` function.
+
+## v1.4.0
+- New method of Fixed Amount of Neighbors (FAN) method to create recurrence plots.
+- Now `AbstractRecurrenceMatrix` types have a parameter with the possible values:
+    * `WithinRange`: when neighboring points are determined by a given distance in the phase space.
+    * `NeighborNumber`: when each point has a determined number of neighbors.  
+- Input arguments of `RecurrenceMatrix`, etc. are generalized to `AbstractDataset`.
+
+## v1.3.2
+- Bugfixes of `transitivity`
+- Deprecate `AbstractMatrix` inputs to `RecurrenceMatrix` etc., in favor of `Dataset`.
+
 ## v1.3.0
 - Increased performance of `RecurrenceMatrix`.
 - Possible to make `JointRecurrenceMatrix` from input arguments.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecurrenceAnalysis"
 uuid = "639c3291-70d9-5ea2-8c5b-839eba1ee399"
 repo = "https://github.com/JuliaDynamics/RecurrenceAnalysis.jl.git"
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -26,6 +26,7 @@ for Recurrence Network Analysis provided in this package.
 
 [1] : R.V. Donner *et al.* "Recurrence networks — a novel paradigm for nonlinear time series analysis",
 *New Journal of Physics* 12, 033025 (2010).
+[DOI:10.1088/1367-2630/12/3/033025](https://doi.org/10.1088/1367-2630/12/3/033025)
 
 [2] : R.V. Donner *et al.* "Complex Network Analysis of Recurrences", in:
 Webber, C.L. & Marwan N. (eds.) *Recurrence Quantification Analysis.

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -76,7 +76,7 @@ Objects of type `<:AbstractRecurrenceMatrix` are displayed as a [`recurrenceplot
 
 ## Description
 
-The recurrence matrix is a numeric representation of a "recurrence plot" [^1, ^2],
+The recurrence matrix is a numeric representation of a "recurrence plot" [1, 2],
 in the form of a sparse square matrix of Boolean values.
 
 `x` must be a `Vector` or an `AbstractDataset`
@@ -121,10 +121,11 @@ See also: [`CrossRecurrenceMatrix`](@ref), [`JointRecurrenceMatrix`](@ref) and
 use [`recurrenceplot`](@ref) to turn the result of these functions into a plottable format.
 
 ## References
-[^1] : N. Marwan *et al.*, "Recurrence plots for the analysis of complex systems",
+[1] : N. Marwan *et al.*, "Recurrence plots for the analysis of complex systems",
 *Phys. Reports 438*(5-6), 237-329 (2007).
+[DOI:10.1016/j.physrep.2006.11.001](https://doi.org/10.1016/j.physrep.2006.11.001)
 
-[^2] : N. Marwan & C.L. Webber, "Mathematical and computational foundations of
+[2] : N. Marwan & C.L. Webber, "Mathematical and computational foundations of
 recurrence quantifications", in: Webber, C.L. & N. Marwan (eds.), *Recurrence
 Quantification Analysis. Theory and Best Practices*, Springer, pp. 3-43 (2015).
 """

--- a/src/rna.jl
+++ b/src/rna.jl
@@ -14,10 +14,10 @@ valid inputs to the `SimpleGraph` constructor of the
 ## Return
 
 The returned value is a dictionary that contains the following entries,
-with the corresponding global network properties[^1][^2]:
+with the corresponding global network properties[1, 2]:
 * `:density`: edge density, approximately equivalent to the global recurrence rate in the phase space.
 * `:transitivity`: network transitivity, which describes the
-global clustering of points following Barrat's and Weigt's formulation [^3].
+global clustering of points following Barrat's and Weigt's formulation [3].
 * `:averagepath`: mean value of the shortest path lengths taken over
 all pairs of connected vertices, related to the average separation
 between points in the phase.
@@ -26,14 +26,17 @@ pairs of connected vertices, related to the phase space diameter.
 
 ## References
 
-[^1]: R.V. Donner *et al.* ["Recurrence networks — a novel paradigm for nonlinear time series analysis",
-*New Journal of Physics* 12, 033025 (2010)](https://doi.org/10.1088/1367-2630/12/3/033025)
+[1]: R.V. Donner *et al.* "Recurrence networks — a novel paradigm for nonlinear time series analysis",
+*New Journal of Physics* 12, 033025 (2010)
+[DOI:10.1088/1367-2630/12/3/033025](https://doi.org/10.1088/1367-2630/12/3/033025)
 
-[^2]: R.V. Donner *et al.*, [The geometry of chaotic dynamics — a complex network perspective,
-*Eur. Phys. J.* B 84, 653–672 (2011)](https://doi.org/10.1140/epjb/e2011-10899-1)
+[2]: R.V. Donner *et al.*, The geometry of chaotic dynamics — a complex network perspective,
+*Eur. Phys. J.* B 84, 653–672 (2011)
+[DOI:10.1140/epjb/e2011-10899-1](https://doi.org/10.1140/epjb/e2011-10899-1)
 
-[^3]: A. Barrat & M. Weight, ["On the properties of small-world network models",
-*The European Physical Journal B* 13, 547–560 (2000)](https://doi.org/10.1007/s100510050067)
+[3]: A. Barrat & M. Weight, "On the properties of small-world network models",
+*The European Physical Journal B* 13, 547–560 (2000)
+[DOI:10.1007/s100510050067](https://doi.org/10.1007/s100510050067)
 """
 function rna(args...; kwargs...)
     graph = SimpleGraph(args...; kwargs...)

--- a/src/rqa.jl
+++ b/src/rqa.jl
@@ -41,6 +41,7 @@ explicitly exclude the LOI or other diagonals around it.
 
 [1] : N. Marwan *et al.*, "Recurrence plots for the analysis of complex systems",
 *Phys. Reports 438*(5-6), 237-329 (2007).
+[DOI:10.1016/j.physrep.2006.11.001](https://doi.org/10.1016/j.physrep.2006.11.001)
 
 [2] : C.L. Webber & J.P. Zbilut, "Recurrence Quantification Analysis of Nonlinear
 Dynamical Systems", in: Riley MA & Van Orden GC, Tutorials in Contemporary
@@ -344,7 +345,8 @@ of recurrence times [1].
 ## References
 
 [1] : E.J. Ngamga *et al.* "Recurrence analysis of strange nonchaotic dynamics",
-*Physical Review E*, 75(3), 036222(1-8), 2007, DOI:10.1103/physreve.75.036222
+*Physical Review E*, 75(3), 036222(1-8) (2007)
+[DOI:10.1103/physreve.75.036222](https://doi.org/10.1103/physreve.75.036222)
 
 """
 nmprt(R::ARM; kwargs) = maximum(verticalhistograms(R; kwargs...)[2])


### PR DESCRIPTION
improve consistency of references in docstrings - and remove links to them as footnotes, such that they are not moved out of the documentation boxes in the pages generated by Documenter.jl