### PR TITLE
Do not pirate `show` for sparse matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecurrenceAnalysis"
 uuid = "639c3291-70d9-5ea2-8c5b-839eba1ee399"
 repo = "https://github.com/JuliaDynamics/RecurrenceAnalysis.jl.git"
-version = "1.6.3"
+version = "1.6.4"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"

--- a/src/matrices/plot.jl
+++ b/src/matrices/plot.jl
@@ -85,7 +85,7 @@ function recurrenceplot(io::IO, R::Union{ARM,SparseMatrixCSC}; minh = 25, maxh =
     )
 end
 
-function Base.show(io::IO, ::MIME"text/plain", R::Union{ARM,SparseMatrixCSC})
+function Base.show(io::IO, ::MIME"text/plain", R::ARM)
     a = recurrenceplot(io, R)
     show(io, a)
 end


### PR DESCRIPTION
This is not convenient anymore, as Julia represents big sparse matrices with Braille patterns since v1.6 (https://github.com/JuliaLang/julia/pull/33821). Actually, perhaps we could even use that representation for `AbstractRecurrenceMatrix`.