### PR TITLE
use `eachindex` and `axes` in loops

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # RecurrenceAnalysis.jl News
 
+## v1.8.1
+- Better support for iteration over `AbstractRecurrenceMatrix` with functions from `Base`.
+
 ## v1.8.0
 - Switch to Graphs.jl from LightGraphs.jl for RNA.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecurrenceAnalysis"
 uuid = "639c3291-70d9-5ea2-8c5b-839eba1ee399"
 repo = "https://github.com/JuliaDynamics/RecurrenceAnalysis.jl.git"
-version = "1.8.0"
+version = "1.8.1"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -73,9 +73,9 @@ function transitivity(R::AbstractRecurrenceMatrix)
     end
     R² = R.data * R.data
     numerator = zero(eltype(R²))
-    for col = 1:size(R,2)
+    for col in axes(R,2)
         rows = view(rowvals(R), nzrange(R,col))
-        for r = rows
+        for r in rows
             numerator += R²[r, col]
         end
     end

--- a/src/matrices/distance_matrix.jl
+++ b/src/matrices/distance_matrix.jl
@@ -62,7 +62,7 @@ function _distancematrix(x::AbstractDataset{S,Tx}, y::AbstractDataset{S,Ty},
     y = y.data
     d = zeros(promote_type(Tx,Ty), length(x), length(y))
     for j in eachindex(y), i in eachindex(x)
-        @inbounds d[i,j] = evaluate(metric, x[ij], y[j])
+        @inbounds d[i,j] = evaluate(metric, x[i], y[j])
     end
     return d
 end

--- a/src/matrices/distance_matrix.jl
+++ b/src/matrices/distance_matrix.jl
@@ -61,10 +61,8 @@ function _distancematrix(x::AbstractDataset{S,Tx}, y::AbstractDataset{S,Ty},
     x = x.data
     y = y.data
     d = zeros(promote_type(Tx,Ty), length(x), length(y))
-    for j in 1:length(y)
-        for i in 1:length(x)
-            @inbounds d[i,j] = evaluate(metric, x[i], y[j])
-        end
+    for j in eachindex(y), i in eachindex(x)
+        @inbounds d[i,j] = evaluate(metric, x[ij], y[j])
     end
     return d
 end
@@ -77,8 +75,8 @@ function _distancematrix(x::AbstractDataset{S,Tx}, y::AbstractDataset{S,Ty},
     x = x.data
     y = y.data
     d = zeros(promote_type(Tx,Ty), length(x), length(y))
-    Threads.@threads for j in 1:length(y)
-        for i in 1:length(x)
+    Threads.@threads for j in eachindex(y)
+        for i in eachindex(x)
             @inbounds d[i,j] = evaluate(metric, x[i], y[j])
         end
     end
@@ -91,8 +89,8 @@ function _distancematrix(x::Matrix{Tx}, y::Matrix{Ty},
     x = x.data
     y = y.data
     d = zeros(promote_type(Tx,Ty), length(x), length(y))
-    Threads.@threads for j in 1:length(y)
-        for i in 1:length(x)
+    Threads.@threads for j in eachindex(y)
+        for i in eachindex(x)
             @inbounds d[i,j] = evaluate(metric, x[i, :], y[j, :])
         end
     end
@@ -108,7 +106,7 @@ end
 function _distancematrix(x::Vector{T}, metric::Metric, ::Val{false}) where T
     d = zeros(T, length(x), length(x))
 
-    for j in 1:length(x)
+    for j in eachindex(x)
         for i in 1:j
             @inbounds d[i, j] = abs(x[i] - x[j])
         end
@@ -121,7 +119,7 @@ end
 function _distancematrix(x::AbstractDataset{S, T}, metric::Metric, ::Val{false}) where T where S
     d = zeros(T, length(x), length(x))
 
-    for j in 1:length(x)
+    for j in eachindex(x)
         for i in 1:j
             @inbounds d[i, j] = evaluate(metric, x[i], x[j])
         end

--- a/src/matrices/matrices.jl
+++ b/src/matrices/matrices.jl
@@ -53,7 +53,7 @@ LinearAlgebra.issymmetric(::JointRecurrenceMatrix{WithinRange}) = true
 # column values in sparse matrix (parallel to rowvals)
 function colvals(x::SparseMatrixCSC)
     cv = zeros(Int,nnz(x))
-    @inbounds for c=1:size(x,2)
+    @inbounds for c in axes(x,2)
         cv[nzrange(x,c)] .= c
     end
     cv
@@ -307,7 +307,7 @@ function get_fan_threshold(x, y, metric, ε)
     if x === y
         ε += 1/length(x)
     end
-    for i in 1:size(d, 2)
+    for i in axes(d, 2)
         fan_threshold[i] = quantile(view(d, : ,i), ε)
     end
     return fan_threshold
@@ -340,9 +340,9 @@ function recurrence_matrix(xx::AbstractDataset, yy::AbstractDataset, metric::Met
     @assert ε isa Real || length(ε) == length(y)
     rowvals = Vector{Int}()
     colvals = Vector{Int}()
-    for j in 1:length(y)
+    for j in eachindex(y)
         nzcol = 0
-        for i in 1:length(x)
+        for i in eachindex(x)
             @inbounds if evaluate(metric, x[i], y[j]) ≤ ( (ε isa Real) ? ε : ε[j] )
                 push!(rowvals, i)
                 nzcol += 1
@@ -359,9 +359,9 @@ function recurrence_matrix(x::AbstractVector, y::AbstractVector, metric::Metric,
     @assert ε isa Real || length(ε) == length(y)
     rowvals = Vector{Int}()
     colvals = Vector{Int}()
-    for j in 1:length(y)
+    for j in eachindex(y)
         nzcol = 0
-        for i in 1:length(x)
+        for i in eachindex(x)
             if @inbounds abs(x[i] - y[j]) ≤ ( (ε isa Real) ? ε : ε[j] )
                 push!(rowvals, i)
                 nzcol += 1
@@ -378,7 +378,7 @@ function recurrence_matrix(x::AbstractVector, metric::Metric, ε, ::Val{false})
     @assert ε isa Real || length(ε) == length(y)
     rowvals = Vector{Int}()
     colvals = Vector{Int}()
-    for j in 1:length(x)
+    for j in eachindex(x)
         nzcol = 0
         for i in 1:j
             if @inbounds abs(x[i] - x[j]) ≤ ( (ε isa Real) ? ε : ε[j] )
@@ -397,7 +397,7 @@ function recurrence_matrix(xx::AbstractDataset, metric::Metric, ε, ::Val{false}
     @assert ε isa Real || length(ε) == length(y)
     rowvals = Vector{Int}()
     colvals = Vector{Int}()
-    for j in 1:length(x)
+    for j in eachindex(x)
         nzcol = 0
         for i in 1:j
             @inbounds if evaluate(metric, x[i], x[j]) ≤ ( (ε isa Real) ? ε : ε[j] )
@@ -426,10 +426,10 @@ function recurrence_matrix(xx::AbstractDataset, yy::AbstractDataset, metric::Met
     colvals = [Vector{Int}() for _ in 1:Threads.nthreads()]
 
     # This is the same logic as the serial function, but parallelized.
-    Threads.@threads for j in 1:length(y)
+    Threads.@threads for j in eachindex(y)
         threadn = Threads.threadid()
         nzcol = 0
-        for i in 1:length(x)
+        for i in eachindex(x)
             @inbounds if evaluate(metric, x[i], y[j]) ≤ ( (ε isa Real) ? ε : ε[j] )
                 push!(rowvals[threadn], i) # push to the thread-specific row array
                 nzcol += 1
@@ -453,10 +453,10 @@ function recurrence_matrix(x::AbstractVector, y::AbstractVector, metric::Metric,
     colvals = [Vector{Int}() for _ in 1:Threads.nthreads()]
 
     # This is the same logic as the serial function, but parallelized.
-    Threads.@threads for j in 1:length(y)
+    Threads.@threads for j in eachindex(y)
         threadn = Threads.threadid()
         nzcol = 0
-        for i in 1:length(x)
+        for i in eachindex(x)
             @inbounds if abs(x[i] - y[j]) ≤ ( (ε isa Real) ? ε : ε[j] )
                 push!(rowvals[threadn], i) # push to the thread-specific row array
                 nzcol += 1

--- a/src/matrices/matrices.jl
+++ b/src/matrices/matrices.jl
@@ -33,7 +33,7 @@ Base.show(io::IO, R::AbstractRecurrenceMatrix) = println(io, summary(R))
 # Propagate used functions:
 begin
     extentions = [
-        (:Base, (:getindex, :size, :length, :view, :iterate)),
+        (:Base, (:getindex, :size, :length, :view, :iterate, :eachindex, :axes, :CartesianIndices)),
         (:LinearAlgebra, (:diag, :triu, :tril, :issymmetric)),
         (:SparseArrays, (:nnz, :rowvals, :nzrange, :nonzeros))
     ]

--- a/src/matrices/skeletonization.jl
+++ b/src/matrices/skeletonization.jl
@@ -128,8 +128,8 @@ function build_skeletonized_RP(lines1::Vector{Int}, lines2::Vector{Int}, lines3:
 
     X_cl_new = spzeros(Bool, N, M)
     # fill up close returns map with lines stored in the new line matrix
-    @inbounds for i = 1:length(lines1)
-        for j = 1:lines1[i]
+    @inbounds for i in eachindex(lines1)
+        for j in 1:lines1[i]
             X_cl_new[lines2[i]+j-1, lines3[i]] = true
         end
     end
@@ -145,13 +145,13 @@ function build_skeletonized_RP(lines1::Vector{Int}, lines2::Vector{Int}, lines3:
     X_cl_new = spzeros(Bool, N, M)
     X_cl2_new = spzeros(Bool, N, M)
     # fill up close returns map with lines stored in the new line matrix
-    @inbounds for i = 1:length(lines1)
-        for j = 1:lines1[i]
+    @inbounds for i in eachindex(lines1)
+        for j in 1:lines1[i]
             X_cl_new[lines2[i]+j-1, lines3[i]] = true
         end
     end
-    @inbounds for i = 1:length(lines11)
-        for j = 1:lines11[i]
+    @inbounds for i in eachindex(lines11)
+        for j in 1:lines11[i]
             X_cl2_new[lines22[i]+j-1,lines33[i]] = true
         end
     end
@@ -177,7 +177,7 @@ function get_final_line_matrix(lines1t::Vector{Int}, lines1l::Vector{Int},
     Nlines1 = length(lines1t) # number of found lines
 
     # go through all lines stored in the sorted line matrix
-    @inbounds for l_ind = 1:Nlines1
+    @inbounds for l_ind in 1:Nlines1
         # check if line is still in the rendered line matrix
         common_ind = intersect(findall(x-> x==true, lines1t[l_ind] .== lines_copy1t),
                         findall(x-> x==true, lines1l[l_ind] .== lines_copy1l),
@@ -194,9 +194,9 @@ function get_final_line_matrix(lines1t::Vector{Int}, lines1l::Vector{Int},
         # go along each point of the line and check for neighbours
         l_max = lines1t[l_ind]
 
-        @inbounds for l = 1:l_max
+        @inbounds for l in 1:l_max
             # scan each line twice - above and underneth
-            for index = -1:2:1
+            for index in -1:2:1
                 # make sure not to exceed RP-boundaries
                 (columni+index > M || columni+index == 0) ? break : nothing
                 # if there is a neighbouring point, call recursive scan-function
@@ -238,7 +238,7 @@ function verticalhisto(R::SparseMatrixCSC)
     cprev = cols[1]
     r1 = rows[1]
     rprev = r1 - 1 # coerce that (a) is not hit in the first iteration
-    @inbounds for i=1:n
+    @inbounds for i in 1:n
         r = rows[i]
         c = cols[i]
         # Search the second and later segments in the column
@@ -300,7 +300,7 @@ function scan_lines!(XX::SparseMatrixCSC, l_vec1::AbstractVector{<:Integer}, l_v
     deleteat!(l_vec3, del_ind)
 
     # check for borders of the RP
-    for i = 1:len
+    for i in 1:len
         newli, newco = neighborindices(XX, i, li, co)
         if newli != 0 && newco != 0
             scan_lines!(XX, l_vec1, l_vec2, l_vec3, newli, newco)

--- a/src/rna/graphs.jl
+++ b/src/rna/graphs.jl
@@ -34,7 +34,7 @@ Theory and Best Practices*, Springer, pp. 101-165 (2015).
 """
 function Graphs.SimpleGraphs.SimpleGraph(R::AbstractRecurrenceMatrix)
     graph = SimpleGraph(R.data)
-    delta = SimpleGraphFromIterator(Edge(v,v) for v in axes(graph, 1))
+    delta = SimpleGraphFromIterator(Edge(v,v) for v in 1:size(graph, 1))
     graph = difference(graph, delta)
     return graph
 end

--- a/src/rna/graphs.jl
+++ b/src/rna/graphs.jl
@@ -34,7 +34,7 @@ Theory and Best Practices*, Springer, pp. 101-165 (2015).
 """
 function Graphs.SimpleGraphs.SimpleGraph(R::AbstractRecurrenceMatrix)
     graph = SimpleGraph(R.data)
-    delta = SimpleGraphFromIterator(Edge(v,v) for v=1:size(graph, 1))
+    delta = SimpleGraphFromIterator(Edge(v,v) for v in axes(graph, 1))
     graph = difference(graph, delta)
     return graph
 end

--- a/src/rqa/histograms.jl
+++ b/src/rqa/histograms.jl
@@ -48,7 +48,7 @@ function _linehistograms(rows::T, cols::T, lmin::Integer, theiler::Integer,
     r1 = rows[firstindex]
     rprev = r1 - 1 # coerce that (a) is not hit in the first iteration
     dist = 0 # placeholder for distances between segments
-    @inbounds for i=firstindex:n
+    @inbounds for i in firstindex:n
         r = rows[i]
         c = cols[i]
         if abs(r-c) ≥ theiler

--- a/src/rqa/radius.jl
+++ b/src/rqa/radius.jl
@@ -5,7 +5,7 @@ function radius_mrr(x::AbstractVector, rr::Real)
     nr == 0 && error("the recurrence rate does not account for more than one sample")
     xs = sort(x)
     d = zeros(lx)
-    for i=1:lx
+    for i in 1:lx
         dxs = xs[max(1,i-nr+1):min(lx,i+nr-1)] - xs[i]
         d[i] = sort(abs.(dxs))[nr]
     end
@@ -37,7 +37,7 @@ function sorteddistances(x; theiler::Integer=0, scale=1, kwargs...)
     ntheiler = theiler*n - theiler*(theiler-1)/2
     distarray = zeros(round(Integer,nd-ntheiler))
     pos = 0
-    for d = 1:n
+    for d in 1:n
         tmp = dm[d+theiler:n,d]
         distarray[pos .+ (1:length(tmp))] .= tmp
         pos += length(tmp)

--- a/src/rqa/rqa.jl
+++ b/src/rqa/rqa.jl
@@ -236,7 +236,7 @@ function tau_recurrence(R::Union{ARM,SparseMatrixCSC})
     n = minimum(size(R))
     rv = rowvals(R)
     rr_τ = zeros(n)
-    @inbounds for col=1:n
+    @inbounds for col in 1:n
         for i in nzrange(R, col)
             if (r=rv[i]) ≤ n
                 d = abs(r-col)
@@ -257,7 +257,7 @@ function _trend(rr_τ::Vector; theiler=1, border=10, kwargs...)::Float64
     b = nmax-border
     numerator = denominator = 0.0
     mean_rr = mean(@view rr_τ[a:b])
-    for d = a:b
+    for d in a:b
         δ = d - b/2
         numerator += δ*(rr_τ[d] - mean_rr)
         denominator += δ*δ

--- a/src/rqa/windowed.jl
+++ b/src/rqa/windowed.jl
@@ -63,7 +63,7 @@ function ij_block_rmat(x, y, bsize, dindex, vargs...; kwargs...)
     ix = iy = 0:0
     rws = (Int)[]
     cls = (Int)[]
-    for i=abs(dindex):n_fullblocks-1
+    for i in abs(dindex):n_fullblocks-1
         ix = i*bsize .+ brange
         iy = i*bsize .+ brange
         if dindex < 0
@@ -142,7 +142,7 @@ macro windowed(ex, options...)
     if ex.head == :call
         f = ex.args[1]
         # Iteration of RQA functions
-        # fun(x,...) => [fun(x[i+w,i+w],...) for i=0:s:nw]
+        # fun(x,...) => [fun(x[i+w,i+w],...) for i in 0:s:nw]
         if in(f, rqa_funs)
             x = ex.args[2]
             submat = :(mtype($x[i.+w,i.+w])) # e.g. :(RecurrenceMatrix(x[i.+w,i.+w]))
@@ -153,7 +153,7 @@ macro windowed(ex, options...)
                 # only calculate "complete" blocks - until `nw`
                 local nw = size($x,1) - $(dict_op[:width])
                 local mtype = typeof($x) # type of the recurrence matrix
-                ($(rqa_types[f]))[$ex for i=0:s:nw]
+                ($(rqa_types[f]))[$ex for i in 0:s:nw]
             end
             return esc(ret_ex)
         end
@@ -185,7 +185,7 @@ macro windowed(ex, options...)
                     :RTE   => zeros(ni),
                     :NMPRT => zeros(ni)
                 )
-                for i=1:ni
+                for i in 1:ni
                     local rqa_i = $ex
                     if i==1 # filter parameters
                         filter!(p->p.first in keys(rqa_i), rqa_dict)

--- a/test/dynamicalsystems.jl
+++ b/test/dynamicalsystems.jl
@@ -84,8 +84,8 @@ dict_keys = ["Sine wave","White noise","Hénon (chaotic)","Hénon (periodic)"]
     rp_fan = RecurrenceMatrix{FAN}(xe, 0.05; fixedrate=true, parallel = false)
     rp_fan_p = RecurrenceMatrix{FAN}(Dataset(xe), 0.05; parallel = true)
     n = length(xe)
-    @test all(.04 < nnz(cr_fan[:,i])/n < .06 for i=1:size(cr_fan, 2))
-    @test all(.04 < (nnz(rp_fan[:,i])-1)/n < .06 for i=1:size(rp_fan, 2))
+    @test all(.04 < nnz(cr_fan[:,i])/n < .06 for i in axes(cr_fan, 2))
+    @test all(.04 < (nnz(rp_fan[:,i])-1)/n < .06 for i in axes(rp_fan, 2))
     @test .04 < recurrencerate(cr_fan) < .06
     @test .04 < recurrencerate(cr_fan_p) < .06
     @test .04 < recurrencerate(rp_fan) < .06


### PR DESCRIPTION
Replace syntax `for i in 1:length(x)` by `for i in eachindex(x)`, and `for i in 1:size(x,d)` by `for i in axes(x,d)`, as recommended.