### PR TITLE
fix misuse of abstract `Integer`

### DIFF
--- a/src/matrices/plot.jl
+++ b/src/matrices/plot.jl
@@ -169,22 +169,22 @@ function grayscale(R, bwcode::Tuple{TT,T}=(0.0,1.0);
     dims = size(R)
     kwargs = Dict(kwargs)
     if haskey(kwargs, :width) && !haskey(kwargs, :height)
-        width = Integer(kwargs[:width])
-        height = round(Integer, width*dims[2]/dims[1])
+        width = Int(kwargs[:width])
+        height = round(Int, width*dims[2]/dims[1])
         return grayscale(R, bwcode; width=width, height=height)
     elseif haskey(kwargs, :height) && !haskey(kwargs, :width)
-        height = Integer(kwargs[:height])
-        width = round(Integer, height*dims[1]/dims[2])
+        height = Int(kwargs[:height])
+        width = round(Int, height*dims[1]/dims[2])
         return grayscale(R, bwcode; width=width, height=height)
     elseif !haskey(kwargs, :width) || !haskey(kwargs, :height)
-        width, height = Integer.(dims)
+        width, height = Int.(dims)
         return grayscale(R, bwcode; width=width, height=height)
     end
     if exactsize
-        width, height = Integer(kwargs[:width]), Integer(kwargs[:height])
+        width, height = Int(kwargs[:width]), Int(kwargs[:height])
     else
-        width, height = checkgridsize(Integer(kwargs[:width]),
-        Integer(kwargs[:height]), dims)
+        width, height = checkgridsize(Int(kwargs[:width]),
+        Int(kwargs[:height]), dims)
     end
     # initial and final values of the horizontal and vertical blocks
     rows = overlapgrid(width, dims[1])

--- a/src/rqa/radius.jl
+++ b/src/rqa/radius.jl
@@ -35,7 +35,7 @@ function sorteddistances(x; theiler::Integer=0, scale=1, kwargs...)
     n = size(x,1)
     nd = (n+1)*n/2
     ntheiler = theiler*n - theiler*(theiler-1)/2
-    distarray = zeros(round(Integer,nd-ntheiler))
+    distarray = zeros(round(Int, nd-ntheiler))
     pos = 0
     for d = 1:n
         tmp = dm[d+theiler:n,d]


### PR DESCRIPTION
Use `Int` instead of `Integer` when coercing some value to integer.