### PR TITLE
Update docs and source to be more harmonious with rest of DynamicalSystems.jl

### DIFF
--- a/src/RecurrenceAnalysis.jl
+++ b/src/RecurrenceAnalysis.jl
@@ -5,7 +5,6 @@ import Base.Meta.parse
 
 const DEFAULT_METRIC = Euclidean()
 
-
 export RecurrenceMatrix, CrossRecurrenceMatrix, JointRecurrenceMatrix,
        AbstractRecurrenceMatrix, WithinRange, NeighborNumber, FAN
 
@@ -31,7 +30,7 @@ export embed,
        sorteddistances,
        skeletonize,
        @windowed,
-       rna,
+       rna
 
 
 include("matrices/distance_matrix.jl")

--- a/src/RecurrenceAnalysis.jl
+++ b/src/RecurrenceAnalysis.jl
@@ -1,7 +1,6 @@
 module RecurrenceAnalysis
 
 using Distances, Statistics, LinearAlgebra, SparseArrays, DelayEmbeddings, StaticArrays
-import Base.Meta.parse
 
 const DEFAULT_METRIC = Euclidean()
 

--- a/src/RecurrenceAnalysis.jl
+++ b/src/RecurrenceAnalysis.jl
@@ -3,23 +3,7 @@ module RecurrenceAnalysis
 using Distances, Statistics, LinearAlgebra, SparseArrays, DelayEmbeddings, StaticArrays
 import Base.Meta.parse
 
-const METRICS = Dict(
-    "euclidean"=>Euclidean(),
-    "max"=>Chebyshev(),
-    "inf"=>Chebyshev(),
-    "cityblock"=>Cityblock(),
-    "manhattan"=>Cityblock(),
-    "taxicab"=>Cityblock(),
-    "min"=>Cityblock()
-)
 const DEFAULT_METRIC = Euclidean()
-getmetric(m::Metric) = m
-function getmetric(normtype::AbstractString)
-    normtype = lowercase(normtype)
-    !haskey(METRICS,normtype) && error("incorrect norm type. Accepted values are \""
-        *join(keys(METRICS),"\", \"", "\" or \"") * "\".")
-    METRICS[normtype]
-end
 
 
 export RecurrenceMatrix, CrossRecurrenceMatrix, JointRecurrenceMatrix,

--- a/src/RecurrenceAnalysis.jl
+++ b/src/RecurrenceAnalysis.jl
@@ -48,8 +48,7 @@ export embed,
        skeletonize,
        @windowed,
        rna,
-       # deprecated:
-       transitivity
+
 
 include("matrices/distance_matrix.jl")
 include("matrices/matrices.jl")

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -9,7 +9,7 @@ for T in (:WithinRange, :NeighborNumber)
             @warn string("`", $call, "{", $T, "}(x::AbstractMatrix, y, ε; kwargs...)` is deprecated, use `", $call, "{", $T, "}(Dataset(x), y, ε; kwargs...)`")
             $call{$T}(Dataset(x), y, ε; kwargs...)
         end
-        
+
         @eval function $call{$T}(x, y::AbstractMatrix, ε; kwargs...)
             @warn string("`", $call, "{", $T, "}(x, y::AbstractMatrix, ε; kwargs...)` is deprecated, use `", $call, "{", $T, "}(x, Dataset(y), ε; kwargs...)`")
             $call{$T}(x, Dataset(y), ε; kwargs...)
@@ -81,3 +81,5 @@ function transitivity(R::AbstractRecurrenceMatrix)
     end
     trans = numerator / (sum(R²) - LinearAlgebra.tr(R²))
 end
+
+export transitivity

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -85,7 +85,7 @@ end
 export transitivity
 
 
-
+import Base.Meta.parse
 const METRICS = Dict(
     "euclidean"=>Euclidean(),
     "max"=>Chebyshev(),

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -83,3 +83,24 @@ function transitivity(R::AbstractRecurrenceMatrix)
 end
 
 export transitivity
+
+
+
+const METRICS = Dict(
+    "euclidean"=>Euclidean(),
+    "max"=>Chebyshev(),
+    "inf"=>Chebyshev(),
+    "cityblock"=>Cityblock(),
+    "manhattan"=>Cityblock(),
+    "taxicab"=>Cityblock(),
+    "min"=>Cityblock()
+)
+getmetric(m::Metric) = m
+function getmetric(normtype::AbstractString)
+    @warn "specifying metric with strings is deprecated! "*
+    "Use a formal instance of a `Metric` from Distances.jl, e.g., `Euclidean()`."
+    normtype = lowercase(normtype)
+    !haskey(METRICS,normtype) && error("incorrect norm type. Accepted values are \""
+        *join(keys(METRICS),"\", \"", "\" or \"") * "\".")
+    METRICS[normtype]
+end

--- a/src/matrices/matrices.jl
+++ b/src/matrices/matrices.jl
@@ -76,6 +76,9 @@ and with distance threshold `ε`.
 Objects of type `<:AbstractRecurrenceMatrix` are displayed as a [`recurrenceplot`](@ref).
 See the description below for the behavior of the `FAN` version.
 
+See also: [`CrossRecurrenceMatrix`](@ref), [`JointRecurrenceMatrix`](@ref) and
+use [`recurrenceplot`](@ref) to turn the result of these functions into a plottable format.
+
 ## Keyword Arguments
 * `metric = "euclidean"` : metric of the distances, either `Metric` or a string,
    as in [`distancematrix`](@ref).
@@ -94,10 +97,12 @@ See the description below for the behavior of the `FAN` version.
 
 ## Description
 
-The recurrence matrix is a numeric representation of a "recurrence plot" [1, 2],
-in the form of a sparse square matrix of Boolean values.
+The recurrence matrix is a numeric representation of a recurrence plot,
+described in detail in [^Marwan2007] and [^Marwan2015]. It represents a square
+a sparse square matrix of Boolean values that quantifies recurrences in the trajectory,
+i.e., points where the trajectory returns close to itself.
 If `d(x[i], x[j]) ≤ ε` (with `d` the distance function),
-then the cell `(i, j)` of the matrix will have a `true`
+then the entry `(i, j)` of the matrix will have a `true`
 value. The criteria to evaluate distances between data points are defined
 based on the keyword arguments.
 
@@ -108,27 +113,23 @@ with a fixed number of `k` neighbors for each point in the phase space, i.e. the
 of recurrences is the same for all columns of the recurrence matrix.
 In such case, `ε` is taken as the target fixed local recurrence rate,
 defined as a value between 0 and 1, and `scale` and `fixedrate` are ignored.
-This is often referred to in the literature as the method of "Fixed Amount of Nearest Neighbors"
-(or FAN for short). 
+This is often referred to in the literature as the method of
+"Fixed Amount of Nearest Neighbors" (or FAN for short).
 
 `FAN` is nothing more than an alias of [`NeighborNumber`](@ref).
-If no parameter is specified, `RecurrenceMatrix` returns a
+If it isn't specified, `RecurrenceMatrix` returns a
 `RecurrenceMatrix{WithinRange}` object, meaning that recurrences will be taken
-for pairs of data points whose distance is \le  `ε`. Note that while recurrence matrices
+for pairs of data points whose distance is ≤ `ε`. Note that while recurrence matrices
 with neighbors defined within a given range are always symmetric, those defined
 by a fixed amount of neighbors can be non-symmetric.
 
-See also: [`CrossRecurrenceMatrix`](@ref), [`JointRecurrenceMatrix`](@ref) and
-use [`recurrenceplot`](@ref) to turn the result of these functions into a plottable format.
+[^Marwan2007]:
+    N. Marwan *et al.*, "Recurrence plots for the analysis of complex systems",
+    [Phys. Reports 438*(5-6), 237-329 (2007)](https://doi.org/10.1016/j.physrep.2006.11.001)
 
-## References
-[1] : N. Marwan *et al.*, "Recurrence plots for the analysis of complex systems",
-*Phys. Reports 438*(5-6), 237-329 (2007).
-[DOI:10.1016/j.physrep.2006.11.001](https://doi.org/10.1016/j.physrep.2006.11.001)
-
-[2] : N. Marwan & C.L. Webber, "Mathematical and computational foundations of
-recurrence quantifications", in: Webber, C.L. & N. Marwan (eds.), *Recurrence
-Quantification Analysis. Theory and Best Practices*, Springer, pp. 3-43 (2015).
+[^Marwan2015]:
+    N. Marwan & C.L. Webber, *Recurrence Quantification Analysis. Theory and Best Practices*
+    [Springer (2015)](https://link.springer.com/book/10.1007/978-3-319-07155-8)
 """
 function RecurrenceMatrix{WithinRange}(x, ε; metric = DEFAULT_METRIC,
     parallel::Bool = length(x) > 500 && Threads.nthreads() > 1,

--- a/src/matrices/matrices.jl
+++ b/src/matrices/matrices.jl
@@ -9,7 +9,6 @@ The low level interface is contained in the function
 # AbstractRecurrenceMatrix type hierarchy and extensions of methods
 ################################################################################
 const FAN = NeighborNumber
-export FAN
 
 abstract type AbstractRecurrenceMatrix{SearchType} end
 const ARM = AbstractRecurrenceMatrix
@@ -77,7 +76,6 @@ SparseArrays.SparseMatrixCSC(R::ARM) = SparseMatrixCSC(R.data)
 Create a recurrence matrix from trajectory `x` (either a `Dataset` or a `Vector`)
 and with distance threshold `ε`.
 Objects of type `<:AbstractRecurrenceMatrix` are displayed as a [`recurrenceplot`](@ref).
-See the description below for the behavior of the `FAN` version.
 
 See also: [`CrossRecurrenceMatrix`](@ref), [`JointRecurrenceMatrix`](@ref) and
 use [`recurrenceplot`](@ref) to turn the result of these functions into a plottable format.
@@ -129,20 +127,18 @@ end
 RecurrenceMatrix(args...; kwargs...) = RecurrenceMatrix{WithinRange}(args...; kwargs...)
 
 """
-    RecurrenceMatrix{FAN}(x, k::Int; metric = Euclidean(), parallel::Bool)
+    RecurrenceMatrix{FAN}(x, r::Real; metric = Euclidean(), parallel::Bool)
 
 The parametrized constructor `RecurrenceMatrix{FAN}` creates the recurrence matrix
-with a fixed number of `k` neighbors for each point in the phase space, i.e. the number
+with a fixed number of neighbors for each point in the phase space, i.e. the number
 of recurrences is the same for all columns of the recurrence matrix.
-In such case, `ε` is taken as the target fixed local recurrence rate,
-defined as a value between 0 and 1, and `scale` and `fixedrate` are ignored.
+In such case, `r` is taken as the target fixed local recurrence rate,
+defined as a value between 0 and 1 which means that `k = round(Int, r*N)` recurrences
+for each point are identified with `N = length(x)`.
 This is often referred to in the literature as the method of
 "Fixed Amount of Nearest Neighbors" (or FAN for short).
 
-`FAN` is nothing more than an alias of [`NeighborNumber`](@ref).
-If it isn't specified, `RecurrenceMatrix` returns a
-`RecurrenceMatrix{WithinRange}` object, meaning that recurrences will be taken
-for pairs of data points whose distance is ≤ `ε`. Note that while recurrence matrices
+Note that while recurrence matrices
 with neighbors defined within a given range are always symmetric, those defined
 by a fixed amount of neighbors can be non-symmetric.
 """
@@ -228,7 +224,7 @@ Create a joint recurrence matrix from given recurrence matrices `R1, R2`.
 """
 function JointRecurrenceMatrix(
     R1::AbstractRecurrenceMatrix{SearchType}, R2::AbstractRecurrenceMatrix{SearchType}; kwargs...
-    ) where T
+    ) where SearchType
     R3 = R1.data .* R2.data
     return JointRecurrenceMatrix{SearchType}(R3)
 end

--- a/src/matrices/matrices.jl
+++ b/src/matrices/matrices.jl
@@ -69,52 +69,52 @@ SparseArrays.SparseMatrixCSC{T}(R::ARM) where T = SparseMatrixCSC{T}(R.data)
 SparseArrays.SparseMatrixCSC(R::ARM) = SparseMatrixCSC(R.data)
 
 """
-    RecurrenceMatrix(x, ε; kwargs...)
-    RecurrenceMatrix{FAN}(x, ε; kwargs...)
+    RecurrenceMatrix(x, ε::Real; kwargs...)
 
-Create a recurrence matrix from trajectory `x` (either a `Dataset` or a `Vector`).
+Create a recurrence matrix from trajectory `x` (either a `Dataset` or a `Vector`)
+and with distance threshold `ε`.
 Objects of type `<:AbstractRecurrenceMatrix` are displayed as a [`recurrenceplot`](@ref).
+See the description below for the behavior of the `FAN` version.
 
-## Description
-
-The recurrence matrix is a numeric representation of a "recurrence plot" [1, 2],
-in the form of a sparse square matrix of Boolean values.
-
-`x` must be a `Vector` or an `AbstractDataset`
-(possibly representing an embedded phase space; see [`embed`](@ref)).
-If `d(x[i], x[j]) ≤ ε` (with `d` the distance function),
-then the cell `(i, j)` of the matrix will have a `true`
-value. The criteria to evaluate distances between data points are defined
-by the following keyword arguments:
-
-* `scale=1` : a function of the distance matrix (see [`distancematrix`](@ref)),
+## Keyword Arguments
+* `metric = "euclidean"` : metric of the distances, either `Metric` or a string,
+   as in [`distancematrix`](@ref).
+* `scale = 1` : a function of the distance matrix (see [`distancematrix`](@ref)),
   or a fixed number, used to scale the value of `ε`. Typical choices are
   `maximum` or `mean`, such that the threshold `ε` is defined as a ratio of the
   maximum or the mean distance between data points, respectively (using
   `mean` or `maximum` calls specialized versions that are faster than the naive
   approach).  Use `1` to keep the distances unscaled (default).
-* `fixedrate::Bool=false` : a flag that indicates if `ε` should be
+* `fixedrate::Bool = false` : a flag that indicates if `ε` should be
   taken as a target fixed recurrence rate (see [`recurrencerate`](@ref)).
   If `fixedrate` is set to `true`, `ε` must be a value between 0 and 1,
   and `scale` is ignored.
-* `metric="euclidean"` : metric of the distances, either `Metric` or a string,
-   as in [`distancematrix`](@ref).
-* `parallel::Bool=false` : whether to parallelize the computation of the recurrence
-   matrix.  This will split the computation of the matrix across multiple threads.
+* `parallel::Bool = false` : whether to parallelize the computation of the recurrence
+   matrix. This will split the computation of the matrix across multiple threads.
 
-The parametrized constructor `RecurrenceMatrix{NeighborNumber}` creates the recurrence matrix
-with a fixed number of neighbors for each point in the phase space, i.e. the number
+## Description
+
+The recurrence matrix is a numeric representation of a "recurrence plot" [1, 2],
+in the form of a sparse square matrix of Boolean values.
+If `d(x[i], x[j]) ≤ ε` (with `d` the distance function),
+then the cell `(i, j)` of the matrix will have a `true`
+value. The criteria to evaluate distances between data points are defined
+based on the keyword arguments.
+
+    RecurrenceMatrix{FAN}(x, k::Int; kwargs...)
+
+The parametrized constructor `RecurrenceMatrix{FAN}` creates the recurrence matrix
+with a fixed number of `k` neighbors for each point in the phase space, i.e. the number
 of recurrences is the same for all columns of the recurrence matrix.
 In such case, `ε` is taken as the target fixed local recurrence rate,
 defined as a value between 0 and 1, and `scale` and `fixedrate` are ignored.
 This is often referred to in the literature as the method of "Fixed Amount of Nearest Neighbors"
-(or FAN for short); `RecurrenceMatrix{FAN}` can be used as a convenient alias
-for `RecurrenceMatrix{NeighborNumber}`.
+(or FAN for short). 
 
+`FAN` is nothing more than an alias of [`NeighborNumber`](@ref).
 If no parameter is specified, `RecurrenceMatrix` returns a
 `RecurrenceMatrix{WithinRange}` object, meaning that recurrences will be taken
-for pairs of data points whose distance is within the range determined by
-the input arguments. Note that while recurrence matrices
+for pairs of data points whose distance is \le  `ε`. Note that while recurrence matrices
 with neighbors defined within a given range are always symmetric, those defined
 by a fixed amount of neighbors can be non-symmetric.
 

--- a/src/matrices/matrices.jl
+++ b/src/matrices/matrices.jl
@@ -322,7 +322,7 @@ get_fan_threshold(x, metric, ε) = get_fan_threshold(x, x, metric, ε)
 
 
 ################################################################################
-# recurrence_matrix - Low level interface
+# recurrence_matrix - Low level function
 ################################################################################
 # TODO: increase the efficiency here by not computing everything!
 

--- a/src/matrices/matrices.jl
+++ b/src/matrices/matrices.jl
@@ -255,10 +255,7 @@ resolve_scale(x, metric, ε) = resolve_scale(x, x, metric, ε)
 # If `scale` is a function, compute the numeric value of the scale based on the
 # distance matrix; otherwise return the value of `scale` itself
 _computescale(scale::Real, args...) = scale
-_computescale(scale::Function, x, metric::Metric) =
-_computescale(scale, x, x, metric)
 
-# generic method that uses `distancematrix`
 function _computescale(scale::Function, x, y, metric)
     if x===y
         distances = zeros(Int(length(x)*(length(x)-1)/2), 1)

--- a/src/matrices/matrices.jl
+++ b/src/matrices/matrices.jl
@@ -11,16 +11,16 @@ The low level interface is contained in the function
 const FAN = NeighborNumber
 export FAN
 
-abstract type AbstractRecurrenceMatrix{T} end
+abstract type AbstractRecurrenceMatrix{SearchType} end
 const ARM = AbstractRecurrenceMatrix
 
-struct RecurrenceMatrix{T} <: AbstractRecurrenceMatrix{T}
+struct RecurrenceMatrix{SearchType} <: AbstractRecurrenceMatrix{SearchType}
     data::SparseMatrixCSC{Bool,Int}
 end
-struct CrossRecurrenceMatrix{T} <: AbstractRecurrenceMatrix{T}
+struct CrossRecurrenceMatrix{SearchType} <: AbstractRecurrenceMatrix{SearchType}
     data::SparseMatrixCSC{Bool,Int}
 end
-struct JointRecurrenceMatrix{T} <: AbstractRecurrenceMatrix{T}
+struct JointRecurrenceMatrix{SearchType} <: AbstractRecurrenceMatrix{SearchType}
     data::SparseMatrixCSC{Bool,Int}
 end
 
@@ -64,11 +64,8 @@ end
 colvals(x::ARM) = colvals(x.data)
 
 # Convert to matrices
-Base.Array{T}(R::ARM) where T = Matrix{T}(R.data)
-Base.Matrix{T}(R::ARM) where T = Matrix{T}(R.data)
 Base.Array(R::ARM) = Matrix(R.data)
 Base.Matrix(R::ARM) = Matrix(R.data)
-SparseArrays.SparseMatrixCSC{T}(R::ARM) where T = SparseMatrixCSC{T}(R.data)
 SparseArrays.SparseMatrixCSC(R::ARM) = SparseMatrixCSC(R.data)
 
 ################################################################################
@@ -210,16 +207,16 @@ length, the recurrences are only calculated until the length of the shortest one
 See [`RecurrenceMatrix`](@ref) for details, references and keywords.
 See also: [`CrossRecurrenceMatrix`](@ref).
 """
-function JointRecurrenceMatrix{T}(x, y, ε; kwargs...) where T
+function JointRecurrenceMatrix{SearchType}(x, y, ε; kwargs...) where SearchType
     n = min(size(x,1), size(y,1))
     if n == size(x,1) && n == size(y,1)
-        rm1 = RecurrenceMatrix{T}(x, ε; kwargs...)
-        rm2 = RecurrenceMatrix{T}(y, ε; kwargs...)
+        rm1 = RecurrenceMatrix{SearchType}(x, ε; kwargs...)
+        rm2 = RecurrenceMatrix{SearchType}(y, ε; kwargs...)
     else
-        rm1 = RecurrenceMatrix{T}(x[1:n,:], ε; kwargs...)
-        rm2 = RecurrenceMatrix{T}(y[1:n,:], ε; kwargs...)
+        rm1 = RecurrenceMatrix{SearchType}(x[1:n,:], ε; kwargs...)
+        rm2 = RecurrenceMatrix{SearchType}(y[1:n,:], ε; kwargs...)
     end
-    return JointRecurrenceMatrix{T}(rm1.data .* rm2.data)
+    return JointRecurrenceMatrix{SearchType}(rm1.data .* rm2.data)
 end
 
 JointRecurrenceMatrix(args...; kwargs...) = JointRecurrenceMatrix{WithinRange}(args...; kwargs...)
@@ -230,10 +227,10 @@ JointRecurrenceMatrix(args...; kwargs...) = JointRecurrenceMatrix{WithinRange}(a
 Create a joint recurrence matrix from given recurrence matrices `R1, R2`.
 """
 function JointRecurrenceMatrix(
-    R1::AbstractRecurrenceMatrix{T}, R2::AbstractRecurrenceMatrix{T}; kwargs...
+    R1::AbstractRecurrenceMatrix{SearchType}, R2::AbstractRecurrenceMatrix{SearchType}; kwargs...
     ) where T
     R3 = R1.data .* R2.data
-    return JointRecurrenceMatrix{T}(R3)
+    return JointRecurrenceMatrix{SearchType}(R3)
 end
 
 ################################################################################


### PR DESCRIPTION
To goal of this PR is to increase the quality of documentation and source code to reflect the standards of clarity that DynamicalSystems.jl strives for. This means clarifying docstrings more, using better variable names, removing duplication of source code, and making source code maintainance more natural, i.e., not allowing stuff like specifying distances by strings.

@heliosdrm I have a question, not related with documentation, but also just saw it: why is the default value for `parallel` false, and why is it that we even need a configuration for that? The parallel method should always be used if more than 1 threads are available...? What's the argument against that?