### PR TITLE
Bump UnicodePlots to version 3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ DelayEmbeddings = "2"
 Distances = "0.8, 0.9, 0.10"
 Graphs = "1.6"
 StaticArrays = "0.8,0.9,0.10,0.11,0.12, 1.0"
-UnicodePlots = "0.3, 1, 2"
+UnicodePlots = "0.3, 1, 2, 3"
 julia = "1.5"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecurrenceAnalysis"
 uuid = "639c3291-70d9-5ea2-8c5b-839eba1ee399"
 repo = "https://github.com/JuliaDynamics/RecurrenceAnalysis.jl.git"
-version = "1.8.1"
+version = "1.9.0"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"


### PR DESCRIPTION
Hello,

Just added version 3 of UnicodePlots to Project, and it seems to be working the same as before. I tested it on the [example from DynamicalSystems documentation](https://juliadynamics.github.io/DynamicalSystems.jl/dev/rqa/rplots/#Simple-Recurrence-Plots).

Attaching screenshots for proof:

1. Code output from my main environment containing current stable versions of DynamicalSystems and RecurrenceAnalysis:
![image](https://user-images.githubusercontent.com/34968676/187075916-a5b3ca44-2f71-46ff-80a6-6168977ae43e.png)
2. Code output from the environment with bumped UnicodePlots version:
![image](https://user-images.githubusercontent.com/34968676/187075966-5cf129a7-dd5e-4370-afc8-14c2cd78b1a7.png)
3. Project status of that environment:
![image](https://user-images.githubusercontent.com/34968676/187076011-d84bef11-f4ab-47a0-b9e9-41ef5c792e67.png)
