### PR TITLE
Fix Dict method declaration for RQA type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RecurrenceAnalysis"
 uuid = "639c3291-70d9-5ea2-8c5b-839eba1ee399"
 repo = "https://github.com/JuliaDynamics/RecurrenceAnalysis.jl.git"
-version = "2.1.3"
+version = "2.1.4"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/rqa/rqa.jl
+++ b/src/rqa/rqa.jl
@@ -406,7 +406,7 @@ for f in (:getindex, :get, :length, :keys, :values, :collect, :iterate)
     @eval Base.$f(result::RQA, args...; kwargs...) = $f(result.data, args...; kwargs...)
 end
 
-Dict(rqa::RQA) = rqa.data
+Base.Dict(rqa::RQA) = rqa.data
 
 function Base.show(io::IO, mime::MIME"text/plain", result::RQA)
     print(io, "RQA parameters in ")


### PR DESCRIPTION
Fixes this warning:
```
  1 dependency had output during precompilation:
┌ RecurrenceAnalysis
│  WARNING: Constructor for type "Dict" was extended in `RecurrenceAnalysis` without explicit qualification or import.
│    NOTE: Assumed "Dict" refers to `Base.Dict`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function Dict end`.
│    Hint: To silence the warning, qualify `Dict` as `Base.Dict` in the method signature or explicitly `import Base: Dict`.
```